### PR TITLE
feat: add schedule for when the bot runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ The default configuration is currently set to:
   "postUpdateOptions": ["npmDedupe"],
   "rangeStrategy": "bump",
   "rebaseStalePrs": true,
-  "recreateClosed": true
+  "recreateClosed": true,
+  /* 
+   * This schedule is to overcome prs being rebased outside this 
+   * time and merge-me action merging these as the actions flow 
+   * is green.
+   */
+  "schedule": ["after 10am and before 4pm every weekday"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,14 +100,16 @@ The default configuration is currently set to:
   "rangeStrategy": "bump",
   "rebaseStalePrs": true,
   "recreateClosed": true,
-  /* 
-   * This schedule is to overcome prs being rebased outside this 
-   * time and merge-me action merging these as the actions flow 
-   * is green.
-   */
   "schedule": ["after 10am and before 4pm every weekday"]
 }
 ```
+
+We use the merge-me github action to auto merge PRs and the 
+hosted renovate bot which runs 24/7 we need to use the `schedule` configuration 
+above to ensure that renovate only runs between the desired hours. Not having 
+this configuration allows renovate bot to rebase PRs outside the specified 
+hours which potentially leads to the CI becoming green and merge-me auto 
+merging the PR.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ hosted renovate bot which runs 24/7 we need to use the `schedule` configuration
 above to ensure that renovate only runs between the desired hours. Not having 
 this configuration allows renovate bot to rebase PRs outside the specified 
 hours which potentially leads to the CI becoming green and merge-me auto 
-merging the PR.
+merging the PR. Which led to outages of breaking runtimes that we didn't
+catch.
 
 ## Contributing
 

--- a/default.json
+++ b/default.json
@@ -4,5 +4,6 @@
   "postUpdateOptions": ["npmDedupe"],
   "rangeStrategy": "bump",
   "rebaseStalePrs": true,
-  "recreateClosed": true
+  "recreateClosed": true,
+  "schedule": ["after 10am and before 4pm every weekday"]
 }


### PR DESCRIPTION
This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Does not affect documentation or it has been added or updated.

This PR adds the schedule parameter to the renovate configuration.

The purpose of adding this is to block renovate from running over the weekend. This will also block renovate bot from updating existing PR's which it has opened and have yet to pass CI.
