### PR TITLE
feat: add configuration for TypeScript projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ pre-releases.
 ## Usage
 
 Add a Renovate configuration to your project and use
-`"extends": ["local>ridedott/renovate-config"]` to include the options defined
+`"extends": ["github>ridedott/renovate-config"]` to include the options defined
 as defaults in the **./default.json** configuration:
+
+If you are working in a TypeScript project we recommend using the `typescript`
+preset by extending from `gihub>ridedott/renovate-config:typescript` instead.
 
 ```json
 {
-  "extends": ["local>ridedott/renovate-config"],
+  "extends": ["github>ridedott/renovate-config:typescript"],
   "packageRules": [
     {
       "enabled": false,
@@ -90,27 +93,12 @@ as defaults in the **./default.json** configuration:
 }
 ```
 
-The default configuration is currently set to:
-
-```json
-{
-  "automergeSchedule": ["after 10am and before 4pm every weekday"],
-  "commitMessageAction": "update",
-  "postUpdateOptions": ["npmDedupe"],
-  "rangeStrategy": "bump",
-  "rebaseStalePrs": true,
-  "recreateClosed": true,
-  "schedule": ["after 10am and before 4pm every weekday"]
-}
-```
-
-We use the merge-me github action to auto merge PRs and the 
-hosted renovate bot which runs 24/7 we need to use the `schedule` configuration 
-above to ensure that renovate only runs between the desired hours. Not having 
-this configuration allows renovate bot to rebase PRs outside the specified 
-hours which potentially leads to the CI becoming green and merge-me auto 
-merging the PR. Which led to outages of breaking runtimes that we didn't
-catch.
+We use the merge-me github action to auto merge PRs and the hosted renovate bot
+which runs 24/7 we need to use the `schedule` configuration to ensure that
+renovate only runs between the desired hours. Not having this configuration
+allows renovate bot to rebase PRs outside the specified hours which potentially
+leads to the CI becoming green and merge-me auto merging the PR. Which led to
+outages of breaking runtimes that we didn't catch.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Add a Renovate configuration to your project and use
 as defaults in the **./default.json** configuration:
 
 If you are working in a TypeScript project we recommend using the `typescript`
-preset by extending from `gihub>ridedott/renovate-config:typescript` instead.
+preset by extending from `github>ridedott/renovate-config:typescript` instead.
 
 ```json
 {

--- a/typescript.json
+++ b/typescript.json
@@ -61,12 +61,11 @@
       "groupName": "Jest environment",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchPackagePatterns": [ "jest-*" ],
       "matchPackageNames": [
         "@jest/globals",
         "@types/jest",
         "jest",
-        "jest-environment-node",
-        "jest-mock",
         "ts-jest"
       ]
     },

--- a/typescript.json
+++ b/typescript.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "commitMessageAction": "update",
+  "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
+  "enabledManagers": ["npm", "github-actions", "dockerfile"],
+  "extends": [
+    ":approveMajorUpdates",
+    ":automergeAll",
+    ":combinePatchMinorReleases",
+    ":prConcurrentLimit10",
+    ":prHourlyLimit4",
+    ":prNotPending",
+    "group:nodeJs",
+    "npm:unpublishSafe",
+    "workarounds:typesNodeVersioning"
+  ],
+  "internalChecksAsSuccess": true,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "commitMessagePrefix": "chore(deps-dev): ",
+      "description": "Change default commit prefix to match Dependabot",
+      "matchDepTypes": ["devDependencies"]
+    },
+    {
+      "matchDatasources": ["npm"],
+      "description": "Allow immediate updates of Dott packages",
+      "matchPackagePrefixes": ["@ridedott"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Group all non-breaking updates in production dependencies",
+      "groupName": "production dependencies",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group all non-breaking updates in development dependencies",
+      "excludePackageNames": ["@types/node"],
+      "groupName": "development dependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "dependencyDashboardApproval": false,
+      "description": "Group all @typescript-eslint updates",
+      "groupName": "Typescript ESLint",
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePrefixes": ["@typescript-eslint"],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "dependencyDashboardApproval": false,
+      "description": "Group all Jest related updates",
+      "groupName": "Jest environment",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchPackageNames": [
+        "@jest/globals",
+        "@types/jest",
+        "jest",
+        "jest-environment-node",
+        "jest-mock",
+        "ts-jest"
+      ]
+    },
+    {
+      "description": "Group all non-major GRPC related updates",
+      "groupName": "Non major GRPC",
+      "matchPackagePrefixes": ["@bufbuild", "@connectrpc"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group all major GRPC related updates",
+      "groupName": "Major GRPC",
+      "matchPackagePrefixes": ["@bufbuild", "@connectrpc"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "dependencyDashboardApproval": true,
+      "description": "Require approval for engine updates",
+      "matchDepTypes": ["engines"]
+    }
+  ],
+  "schedule": ["after 10:30am and before 12:30am on Tuesday"],
+  "timezone": "Europe/Amsterdam",
+  "updatePinnedDependencies": false
+}

--- a/typescript.json
+++ b/typescript.json
@@ -87,7 +87,7 @@
       "matchDepTypes": ["engines"]
     }
   ],
-  "schedule": ["after 10:30am and before 12:30am on Tuesday"],
+  "schedule": ["after 10:30am and before 12:30pm on Tuesday"],
   "timezone": "Europe/Amsterdam",
   "updatePinnedDependencies": false
 }

--- a/typescript.json
+++ b/typescript.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "commitMessageAction": "update",
+  "commitMessageAction": "bump",
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
   "enabledManagers": ["npm", "github-actions", "dockerfile"],
@@ -22,6 +22,11 @@
       "commitMessagePrefix": "chore(deps-dev): ",
       "description": "Change default commit prefix to match Dependabot",
       "matchDepTypes": ["devDependencies"]
+    },
+    {
+      "commitMessagePrefix": "chore(deps): ",
+      "description": "Change default commit prefix to match Dependabot",
+      "matchDepTypes": ["dependencies"]
     },
     {
       "matchDatasources": ["npm"],

--- a/typescript.json
+++ b/typescript.json
@@ -61,13 +61,8 @@
       "groupName": "Jest environment",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major", "minor", "patch"],
-      "matchPackagePatterns": [ "jest-*" ],
-      "matchPackageNames": [
-        "@jest/globals",
-        "@types/jest",
-        "jest",
-        "ts-jest"
-      ]
+      "matchPackagePatterns": ["jest-*"],
+      "matchPackageNames": ["@jest/globals", "@types/jest", "jest", "ts-jest"]
     },
     {
       "description": "Group all non-major GRPC related updates",


### PR DESCRIPTION
This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [ ] Does not affect documentation or it has been added or updated.

Attempt to standardize good practices around dependency update in TypeScript projects.

- Safely bumps NPM dependencies only after they’ve been published for 72hrs. Explicitly allowing `@ridedott/*` packages to get immediately updated, we don’t un-publish packages.

- Groups all node dependencies together; `@types/node` NPM package, Dockerfile Node images, `package.json` engines property, etc… to avoid mismatches.

- Ensures PRs are only created during the desired schedule.

- Uses dashboard approval (Renovate) to prevent the creation of PRs containing major updates so you can control when to release a major bump.

- Groups Jest updates together `jest`, `@types/jest`, `jest-mock`, `@jest/globals`, etc… major updates of this group highly likely don’t require explicit dashboard approval. If tests are passing means that the Jest environment is okay.

- Groups ESLint updates together, major updates of this group highly likely don’t require explicit dashboard approval. If linting is passing in the CI means that the ESLint environment is okay.

- Groups GRPC updates together, dependencies like `@bufbuild`, `@connectrpc` need to be updated together. Otherwise one will always block the other. Create two groups one for non-major updates and one for major-updates will allow you to require approval for major bumps.


