### PR TITLE
feat: terrafom lockfileMaintenance

### DIFF
--- a/terraform.json
+++ b/terraform.json
@@ -5,5 +5,6 @@
   "schedule": ["after 10:30am and before 12:30am every weekday"],
   "timezone": "Europe/Amsterdam",
   "commitMessagePrefix": "chore(deps): \uD83D\uDC77 ",
-  "separateMajorMinor": false
+  "separateMajorMinor": false,
+  "lockFileMaintenance": { "enabled": true }
 }


### PR DESCRIPTION
`ridedott/tf-assets/envs/prod/.terraform.lock.hcl` doesn't get udpated by renovate.