### PR TITLE
fix: disable blocking stability check

### DIFF
--- a/typescript.json
+++ b/typescript.json
@@ -12,7 +12,6 @@
     ":prHourlyLimit4",
     ":prNotPending",
     "group:nodeJs",
-    "npm:unpublishSafe",
     "workarounds:typesNodeVersioning"
   ],
   "internalChecksAsSuccess": true,


### PR DESCRIPTION
## Context

The stability check is currently preventing Renovate to create PRs.
We don't have the time right now to figure this out, we'll get back to it ASAP.

## This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Does not affect documentation or it has been added or updated.


