### PR TITLE
feat: allow terraform updates for ridedott/tf-modules with tags prefixed with module name

### DIFF
--- a/terraform.json
+++ b/terraform.json
@@ -6,5 +6,11 @@
   "timezone": "Europe/Amsterdam",
   "commitMessagePrefix": "chore(deps): \uD83D\uDC77 ",
   "separateMajorMinor": false,
-  "lockFileMaintenance": { "enabled": true }
+  "lockFileMaintenance": { "enabled": true },
+  "terraform": {
+    "fileMatch": [
+      "\\.tf$"
+    ],
+    "versioning": "regex:^((?<compatibility>.*)-v|v*)(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+  }
 }


### PR DESCRIPTION
See it working here: https://github.com/ridedott/tf-test-renovate/pull/67

As `compatibility` is question marked, it's optional, so it still works with non prefixed semver like we do it.

See: https://docs.renovatebot.com/configuration-options/#versioncompatibility