### PR TITLE
feat: add rangeStrategy=bump to typescript config

### DIFF
--- a/typescript.json
+++ b/typescript.json
@@ -87,6 +87,7 @@
       "updatePinnedDependencies": false
     }
   ],
+  "rangeStrategy": "bump",
   "schedule": ["after 10:30am and before 12:30pm on Tuesday"],
   "timezone": "Europe/Amsterdam",
   "updatePinnedDependencies": true


### PR DESCRIPTION
I noticed that only package-lock files are being updated. In dependabot we have the `versioning-strategy=increase` option for this. It looks like the equivalent for renovate is to use `rangeStrategy=bump` which is already in the default config, but apparently the default config is not re-used in the typescript config?

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Does not affect documentation or it has been added or updated.
