### PR TITLE
chore: add npmToken from variable

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,5 +5,6 @@
   "rangeStrategy": "bump",
   "rebaseStalePrs": true,
   "recreateClosed": true,
-  "schedule": ["after 10am and before 4pm every weekday"]
+  "schedule": ["after 10am and before 4pm every weekday"],
+  "npmToken": "{{ secrets.GITHUB_TOKEN_DOTT_BOT }}"
 }

--- a/typescript.json
+++ b/typescript.json
@@ -4,6 +4,7 @@
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
   "enabledManagers": ["npm", "github-actions", "dockerfile"],
+  "npmToken": "{{ secrets.GITHUB_TOKEN_DOTT_BOT }}",
   "extends": [
     ":approveMajorUpdates",
     ":automergeAll",


### PR DESCRIPTION
This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Does not affect documentation or it has been added or updated.

<!--


This allows PRs to be resolved automatically once the PR is merged to a base
branch. The following line should be removed if the PR does not affect any open
issues.
-->

The default and typescript config will use the global npm token which is defined as a secret. 
Renovate no longer supports adding encrypted credentials to the config.

<!--
Link to a PR with a documentation update:
-->
